### PR TITLE
Chore: Ensure Python 3.9 Compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,4 @@ test.yaml
 !.github/workflows/python-publish.yml	
 !.github/workflows/tests.yml
 
+poetry.lock

--- a/TypeSaveArgParse/autoargs.py
+++ b/TypeSaveArgParse/autoargs.py
@@ -6,7 +6,7 @@ from functools import partial
 from inspect import signature
 from io import StringIO
 from pathlib import Path
-from typing import get_args, get_origin
+from typing import Optional, Union, get_args, get_origin
 
 import ruamel.yaml
 from configargparse import ArgumentParser
@@ -23,7 +23,7 @@ config_help = "config file path"
 
 def data_class_to_arg_parse(
     cls,
-    parser: None | ArgumentParser = None,
+    parser: Optional[ArgumentParser] = None,
     default_config=None,
     _addendum: str = "",
     _checks=None,
@@ -93,9 +93,9 @@ def data_class_to_arg_parse(
         annotation = parameters[name].annotation
         # Handling :A |B |...| None (None means Optional argument)
         annotations = []
-        if get_origin(annotation) == types.UnionType:
+        if get_origin(annotation) == Union:
             for i in get_args(annotation):
-                if i == types.NoneType:
+                if i == type(None):
                     can_be_none = True
                 else:
                     annotations.append(i)
@@ -231,9 +231,9 @@ def add_comments_to_yaml(cls, data: ruamel.yaml.CommentedMap, _addendum: str = "
 
         # Handling :A |B |...| None (None means Optional argument)
         annotations = []
-        if get_origin(annotation) == types.UnionType:
+        if get_origin(annotation) == Union:
             for i in get_args(annotation):
-                if i != types.NoneType:
+                if i != type(None):
                     annotations.append(i)
                     annotation = i
         if len(annotations) > 1:
@@ -274,7 +274,7 @@ class Class_to_ArgParse:
     """
 
     @classmethod
-    def get_opt(cls, parser: None | ArgumentParser = None, default_config=None):
+    def get_opt(cls, parser: Optional[ArgumentParser] = None, default_config=None):
         """
         Get an instance of the class based on arguments parsed from command line.
 
@@ -372,7 +372,7 @@ class Class_to_ArgParse:
                 self.__dict__[key] = state[key]
         return state
 
-    def save_config(self, outfile: str | Path, default_flow_style: None | bool = None):
+    def save_config(self, outfile: Union[str, Path], default_flow_style: Optional[bool] = None):
         """
         Save the configuration to a YAML file.
 

--- a/TypeSaveArgParse/utils.py
+++ b/TypeSaveArgParse/utils.py
@@ -3,7 +3,7 @@ import sys
 import types
 from enum import Enum
 from inspect import Parameter
-from typing import get_args, get_origin
+from typing import Optional, Union, get_args, get_origin
 
 
 def translation_enum_to_str(enum: type[Enum]) -> list[str]:
@@ -41,7 +41,7 @@ def cast_if_list_to(type_, val, parameter: types.GenericAlias):
     return val
 
 
-def cast_if_enum(val, parameter: types.GenericAlias, enum: None | type):
+def cast_if_enum(val, parameter: types.GenericAlias, enum: Optional[type]):
     # Cast Str to Enum
     if enum is None:
         return val
@@ -59,7 +59,7 @@ def extract_sub_annotation(annotation):
     had_ellipsis = False
     has_optional = False
     for i in get_args(annotation):
-        if i == types.NoneType:
+        if i == type(None):
             has_optional = True
         elif i == Ellipsis:
             had_ellipsis = True
@@ -70,7 +70,7 @@ def extract_sub_annotation(annotation):
 
 
 def _cast_all(val, annotation: types.GenericAlias, enum):  # -> tuple[Any, ...] | set[Any] | Any | list[Any]:
-    if get_origin(annotation) == types.UnionType:
+    if get_origin(annotation) == Union:
         annotation = extract_sub_annotation(annotation)[0]
 
     if isinstance(val, list):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 packages = [{ include = "TypeSaveArgParse" }]
 
 [tool.poetry.dependencies]
-python = "^3.10 || ^3.11 || ^3.12 || ^3.13 || ^3.14 || ^3.15"
+python = "^3.9 || ^3.10 || ^3.11 || ^3.12 || ^3.13 || ^3.14 || ^3.15"
 pathlib = "*"
 ConfigArgParse = "*"
 PyYAML = "*"
@@ -130,6 +130,7 @@ ignore = [
     "SIM118",  # dictionay keys
     "N802",    # function name lowercase
     "E721",
+    "UP007", # | operator python 3.9
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/test/test_autoargs.py
+++ b/test/test_autoargs.py
@@ -8,7 +8,7 @@ import unittest
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from pathlib import Path
-from types import NoneType
+from typing import Optional
 from unittest.mock import patch
 
 import configargparse as argparse
@@ -27,8 +27,8 @@ class BASE_CASES(Class_to_ArgParse):
     x: str = DEFAULT_STR
     y: int = DEFAULT_INT
     f: float = DEFAULT_FLOAT
-    z: int | None = None
-    p: Path | None = None
+    z: Optional[int] = None
+    p: Optional[Path] = None
     l_s: list[str] = field(default_factory=list)
     l_i: list[int] = field(default_factory=lambda: [1, 2, 3])
     tup: tuple[str, ...] = field(default_factory=tuple)
@@ -53,7 +53,7 @@ class Dummy_Enum(Enum):
 @dataclass
 class ENUM_CASES(Class_to_ArgParse):
     enu: Dummy_Enum = Dummy_Enum.ONE
-    enu_list: list[Dummy_Enum] | None = None
+    enu_list: Optional[list[Dummy_Enum]] = None
     enu_list2: list[Dummy_Enum] = field(default_factory=list)
 
 
@@ -66,7 +66,7 @@ def err(idx):
     raise ValueError(idx)
 
 
-def fetch_exit(args: list | None = None, fun=lambda: BASE_CASES().get_opt()):
+def fetch_exit(args: Optional[list[str]] = None, fun=lambda: BASE_CASES().get_opt()):
     if args is None:
         args = [__file__, "--z", "C. CLark"]
     try:
@@ -86,12 +86,12 @@ class Test_autoargs(unittest.TestCase):
             assert_(opt.x, DEFAULT_STR, str)
             assert_(opt.y, DEFAULT_INT, int)
             assert_(opt.f, DEFAULT_FLOAT, float)
-            assert_(opt.z, None, NoneType)
+            assert_(opt.z, None, type(None))
             assert_(opt.l_s, [], list)
             assert_(opt.l_i, [1, 2, 3], list)
             assert_(opt.set_, set(), set)
             assert_(opt.tup, (), tuple)
-            assert_(opt.p, None, NoneType)
+            assert_(opt.p, None, type(None))
         value = "BananaBread"
         with patch("sys.argv", [__file__, "--x", "BananaBread"]):
             opt = BASE_CASES().get_opt()

--- a/test/test_recursive.py
+++ b/test/test_recursive.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from enum import Enum, auto
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from types import NoneType
+from typing import Optional
 from unittest.mock import patch
 
 import configargparse as argparse
@@ -43,8 +43,8 @@ class BASE_CASES(Class_to_ArgParse):
     x: str = DEFAULT_STR
     y: int = DEFAULT_INT
     f: float = DEFAULT_FLOAT
-    z: int | None = None
-    p: Path | None = None
+    z: Optional[int] = None
+    p: Optional[Path] = None
     l_s: list[str] = field(default_factory=list)
     l_i: list[int] = field(default_factory=lambda: [1, 2, 3])
     tup: tuple[str, ...] = field(default_factory=tuple)
@@ -112,7 +112,7 @@ class ENUM_CASES(Class_to_ArgParse):
     """
 
     enu: Dummy_Enum = Dummy_Enum.ONE
-    enu_list: list[Dummy_Enum] | None = None
+    enu_list: Optional[list[Dummy_Enum]] = None
     enu_list2: list[Dummy_Enum] = field(default_factory=list)
 
 
@@ -141,7 +141,7 @@ def err(idx):
     raise ValueError(idx)
 
 
-def fetch_exit(args: list | None = None, fun=lambda: BASE_CASES().get_opt()):
+def fetch_exit(args: Optional[list[str]] = None, fun=lambda: BASE_CASES().get_opt()):
     if args is None:
         args = [__file__, "--z", "C. CLark"]
     try:

--- a/test/test_save_load.py
+++ b/test/test_save_load.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from enum import Enum, auto
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from types import NoneType
+from typing import Optional
 from unittest.mock import patch
 
 import configargparse as argparse
@@ -36,8 +36,8 @@ class BASE_CASES(Class_to_ArgParse):
     f: float = -0.3
     enum: Dummy_Enum = Dummy_Enum.ONE
     enum_tuple: tuple[Dummy_Enum, Dummy_Enum] = field(default_factory=lambda: (Dummy_Enum.ONE, Dummy_Enum.ONE))
-    z: int | None = None
-    p: Path | None = None
+    z: Optional[int] = None
+    p: Optional[Path] = None
     l_s: list[str] = field(default_factory=lambda: ["Wam", "Bam"])
     l_i: list[int] = field(default_factory=lambda: [1, 2, 3])
     tup: tuple[str, ...] = field(default_factory=tuple)


### PR DESCRIPTION
- Python Version Compatibility: Updated the project to work with Python 3.9
- Type Hint Adjustments: Replaced the use of the | operator for unions with Union and Optional from the typing module
- Union Type Detection: Replaced references to types.UnionType with Union
- NoneType References: Replaced types.NoneType with type(None)